### PR TITLE
Fix stacking claim and add claim buttons

### DIFF
--- a/src/components/CityCoinStackingClaim.js
+++ b/src/components/CityCoinStackingClaim.js
@@ -48,7 +48,8 @@ export function CityCoinStackingClaim({ ownerStxAddress }) {
             <div className="card" key={key}>
               <div className="card-header">Cycle {details.cycleId}</div>
               <div className="card-body">
-                <p>{details.amount} STX</p>
+                <p>{details.amountSTX.toLocaleString()} STX</p>
+                <p>{details.amountCC.toLocaleString()} CityCoins</p>
                 <button
                   className="btn btn-outline-primary"
                   onClick={() => claimAction(uintCV(details.cycleId))}

--- a/src/components/CityCoinStackingClaim.js
+++ b/src/components/CityCoinStackingClaim.js
@@ -4,8 +4,8 @@ import { CC_NAME, CITYCOIN_CONTRACT_NAME, CONTRACT_ADDRESS, NETWORK } from '../l
 import {
   uintCV,
   PostConditionMode,
-  makeStandardSTXPostCondition,
-  makeStandardFungiblePostCondition,
+  makeContractSTXPostCondition,
+  makeContractFungiblePostCondition,
   createAssetInfo,
   FungibleConditionCode,
   AnchorMode,
@@ -35,14 +35,16 @@ export function CityCoinStackingClaim({ ownerStxAddress }) {
       functionArgs: [targetRewardCycleCV],
       postConditionMode: PostConditionMode.Deny,
       postConditions: [
-        makeStandardSTXPostCondition(
-          ownerStxAddress,
-          FungibleConditionCode.Equal,
+        makeContractSTXPostCondition(
+          CONTRACT_ADDRESS,
+          CITYCOIN_CONTRACT_NAME,
+          FungibleConditionCode.LessEqual,
           amountUstxCV.value
         ),
-        makeStandardFungiblePostCondition(
-          ownerStxAddress,
-          FungibleConditionCode.Equal,
+        makeContractFungiblePostCondition(
+          CONTRACT_ADDRESS,
+          CITYCOIN_CONTRACT_NAME,
+          FungibleConditionCode.LessEqual,
           amountCityCoinCV.value,
           createAssetInfo(CONTRACT_ADDRESS, CITYCOIN_CONTRACT_NAME, CC_NAME)
         ),

--- a/src/components/CityCoinStackingClaim.js
+++ b/src/components/CityCoinStackingClaim.js
@@ -33,7 +33,7 @@ export function CityCoinStackingClaim({ ownerStxAddress }) {
       contractAddress: CONTRACT_ADDRESS,
       contractName: CITYCOIN_CONTRACT_NAME,
       functionName: 'claim-stacking-reward',
-      functionArgs: [targetRewardCycleCV, amountUstxCV, amountCityCoinCV],
+      functionArgs: [targetRewardCycleCV],
       postConditionMode: PostConditionMode.Deny,
       postConditions: [
         makeStandardSTXPostCondition(

--- a/src/components/CityCoinStackingClaim.js
+++ b/src/components/CityCoinStackingClaim.js
@@ -20,26 +20,22 @@ export function CityCoinStackingClaim({ ownerStxAddress }) {
   }, [ownerStxAddress]);
 
   const claimAction = async () => {
-    if (rewardCycleRef.current.value === '') {
-      console.log('positive number required to claim stacking rewards');
-    } else {
-      setLoading(true);
-      const targetRewardCycleCV = uintCV(rewardCycleRef.current.value.trim());
-      await doContractCall({
-        contractAddress: CONTRACT_ADDRESS,
-        contractName: CITYCOIN_CONTRACT_NAME,
-        functionName: 'claim-stacking-reward',
-        functionArgs: [targetRewardCycleCV],
-        network: NETWORK,
-        onCancel: () => {
-          setLoading(false);
-        },
-        onFinish: result => {
-          setLoading(false);
-          setTxId(result.txId);
-        },
-      });
-    }
+    setLoading(true);
+    const targetRewardCycleCV = uintCV(rewardCycleRef.current.value.trim());
+    await doContractCall({
+      contractAddress: CONTRACT_ADDRESS,
+      contractName: CITYCOIN_CONTRACT_NAME,
+      functionName: 'claim-stacking-reward',
+      functionArgs: [targetRewardCycleCV],
+      network: NETWORK,
+      onCancel: () => {
+        setLoading(false);
+      },
+      onFinish: result => {
+        setLoading(false);
+        setTxId(result.txId);
+      },
+    });
   };
 
   return (
@@ -47,15 +43,22 @@ export function CityCoinStackingClaim({ ownerStxAddress }) {
       <h3>Claim Stacking Rewards</h3>
       <p>Available STX to claim:</p>
       {stackingState && stackingState.length > 0 ? (
-        <ul>
+        <>
           {stackingState.map((details, key) => (
-            <li key={key}>
-              <>
-                {details.amount} STX in cycle {details.cycleId}.
-              </>
-            </li>
+            <div className="card" key={key}>
+              <div className="card-header">Cycle {details.cycleId}</div>
+              <div className="card-body">
+                <p>{details.amount} STX</p>
+                <button
+                  className="btn btn-outline-primary"
+                  onClick={() => claimAction(uintCV(details.cycleId))}
+                >
+                  Claim
+                </button>
+              </div>
+            </div>
           ))}
-        </ul>
+        </>
       ) : loading ? null : (
         <div className="my-2">Nothing to claim</div>
       )}

--- a/src/components/CityCoinStackingClaim.js
+++ b/src/components/CityCoinStackingClaim.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useConnect } from '@stacks/connect-react';
 import { CC_NAME, CITYCOIN_CONTRACT_NAME, CONTRACT_ADDRESS, NETWORK } from '../lib/constants';
-import { TxStatus } from './TxStatus';
 import {
   uintCV,
   PostConditionMode,
@@ -60,6 +59,8 @@ export function CityCoinStackingClaim({ ownerStxAddress }) {
     });
   };
 
+  // TODO: add txstatus back to correlate with each claim button state
+
   return (
     <>
       <h3>Claim Stacking Rewards</h3>
@@ -91,29 +92,6 @@ export function CityCoinStackingClaim({ ownerStxAddress }) {
       ) : loading ? null : (
         <div className="my-2">Nothing to claim</div>
       )}
-      <form>
-        <div className="input-group mb-3">
-          <input
-            type="number"
-            className="form-control"
-            ref={rewardCycleRef}
-            aria-label="Reward Cycle"
-            placeholder="Reward Cycle"
-            required
-            minLength="1"
-          />
-        </div>
-        <button className="btn btn-block btn-primary" type="button" onClick={claimAction}>
-          <div
-            role="status"
-            className={`${
-              loading ? '' : 'd-none'
-            } spinner-border spinner-border-sm text-info align-text-top mr-2`}
-          />
-          Claim Stacking Rewards
-        </button>
-      </form>
-      {txId && <TxStatus txId={txId} />}
     </>
   );
 }

--- a/src/components/CityCoinTxList.js
+++ b/src/components/CityCoinTxList.js
@@ -219,7 +219,10 @@ function Details({ tx }) {
         </small>
       </div>
       <div className="col-lg-6 col-md-12 text-right">
-        <small>{tx.tx_id.substr(0, 20)}...</small>
+        {tx.tx_id.substr(0, 10)}...
+        <a href={`https://explorer.stacks.co/txid/${tx.tx_id}`} target="_blank" rel="noreferrer">
+          <i class="bi bi-box-arrow-up-right" />
+        </a>
       </div>
     </>
   );

--- a/src/components/CityCoinTxList.js
+++ b/src/components/CityCoinTxList.js
@@ -152,6 +152,18 @@ function uintJsonToSTX(value) {
   );
 }
 
+function uintJsonToRewardCycle(value) {
+  return (
+    <>
+      Reward Cycle:{' '}
+      {hexToCV(value.hex).value.toNumber().toLocaleString(undefined, {
+        maximumFractionDigits: 0,
+        style: 'decimal',
+      })}
+    </>
+  );
+}
+
 function RegisterTransaction({ tx }) {
   return <div className="col-12">{tx.contract_call.function_name}</div>;
 }
@@ -187,7 +199,9 @@ function ClaimTransaction({ tx }) {
 function ClaimStackingTransaction({ tx }) {
   return (
     <div className="col-12">
-      {tx.contract_call.function_name} ({tx.events[0].asset.amount})
+      <b>{tx.contract_call.function_name}</b>
+      <br />
+      <small>{uintJsonToRewardCycle(tx.contract_call.function_args[0])}</small>
     </div>
   );
 }

--- a/src/lib/citycoin.js
+++ b/src/lib/citycoin.js
@@ -213,14 +213,7 @@ export async function getAvailableRewards(stxAddress, cycleId) {
     senderAddress: stxAddress,
     network: NETWORK,
   });
-  const result = { amount: stackingReward.value.toNumber(), cycleId, stxAddress };
-  console.log({ result });
-  return result;
-}
-
-export async function getAvailableStackedCitycoins(stxAddress, cycleId) {
-  const info = await infoApi.getCoreApiInfo();
-  const citycoinClaim = await callReadOnlyFunction({
+  const cityCoinClaim = await callReadOnlyFunction({
     contractAddress: CONTRACT_ADDRESS,
     contractName: CITYCOIN_CONTRACT_NAME,
     functionName: 'get-stacked-in-cycle',
@@ -228,7 +221,12 @@ export async function getAvailableStackedCitycoins(stxAddress, cycleId) {
     senderAddress: stxAddress,
     network: NETWORK,
   });
-  const result = { amount: citycoinClaim.value.toNumber(), cycleId, stxAddress };
+  const result = {
+    amountSTX: stackingReward.value.toNumber(),
+    amountCC: cityCoinClaim.value.toNumber(),
+    cycleId,
+    stxAddress,
+  };
   console.log({ result });
   return result;
 }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -28,6 +28,7 @@ export const GENESIS_CONTRACT_ADDRESS = 'ST000000000000000000002AMW42H';
 export const BNS_CONTRACT_NAME = 'bns';
 
 export const CITYCOIN_CONTRACT_NAME = mocknet ? 'citycoin' : 'comfortable-purple-kiwi';
+export const CC_NAME = 'citycoin';
 export const CC_SYMBOL = '$CITY';
 
 // TODO: add Freehold API endpoint?


### PR DESCRIPTION
This PR updates the following:

- adds a new constant `CC_NAME` with the token name for post conditions
- adds a call from `getAvailableRewards` to `get-stacked-in-cycle` to get CityCoins for post conditions
- adds post conditions for both the STX and CityCoins transfers
- adds a single button per claim and removes the form at the bottom

**Note:** this removes the transaction ID and loading state.

Will need to get those added back but want to get the TX to go through first!

Fixes #47 