### PR TITLE
Update claim layouts

### DIFF
--- a/src/components/CityCoinMiningClaim.js
+++ b/src/components/CityCoinMiningClaim.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useConnect } from '@stacks/connect-react';
 import { CC_SYMBOL, CITYCOIN_CONTRACT_NAME, CONTRACT_ADDRESS, NETWORK } from '../lib/constants';
 import { TxStatus } from './TxStatus';
@@ -9,7 +9,6 @@ import { getCoinbase, getMiningDetails } from '../lib/citycoin';
 // get from a getter?
 
 export function CityCoinMiningClaim({ ownerStxAddress }) {
-  const amountRef = useRef();
   const [txId, setTxId] = useState();
   const [loading, setLoading] = useState();
   const [miningState, setMiningState] = useState();
@@ -37,16 +36,6 @@ export function CityCoinMiningClaim({ ownerStxAddress }) {
         setTxId(result.txId);
       },
     });
-  };
-  const mineClaimAction = async () => {
-    setLoading(true);
-    if (amountRef.current.value === '') {
-      console.log('positive number required to claim mining rewards');
-      setLoading(false);
-    } else {
-      const amountUstxCV = uintCV(amountRef.current.value.trim());
-      claimAction(amountUstxCV);
-    }
   };
 
   return (
@@ -99,29 +88,6 @@ export function CityCoinMiningClaim({ ownerStxAddress }) {
       ) : loading ? null : (
         <div className="my-2">No rewards yet</div>
       )}
-      <form>
-        <div className="input-group mb-3">
-          <input
-            type="number"
-            className="form-control"
-            ref={amountRef}
-            aria-label="Block Number"
-            placeholder="Block Number"
-            required
-            minLength="1"
-          />
-        </div>
-        <button className="btn btn-block btn-primary" type="button" onClick={mineClaimAction}>
-          <div
-            role="status"
-            className={`${
-              loading ? '' : 'd-none'
-            } spinner-border spinner-border-sm text-info align-text-top mr-2`}
-          />
-          Claim Mining Rewards
-        </button>
-      </form>
-      {txId && <TxStatus txId={txId} />}
     </>
   );
 }

--- a/src/components/CityCoinMiningClaim.js
+++ b/src/components/CityCoinMiningClaim.js
@@ -54,34 +54,48 @@ export function CityCoinMiningClaim({ ownerStxAddress }) {
       <h3>Claim Mining Rewards</h3>
       <p>Available CityCoins to claim:</p>
       {miningState && miningState.winningDetails.length > 0 ? (
-        <ul>
+        <div class="row">
           {miningState.winningDetails.map((details, key) =>
             details.lost ? null : (
-              <li key={key}>
-                {details.winner ? (
-                  details.claimed ? (
+              <div className="col-3 card" key={key}>
+                <div className="card-header">Block {details.blockHeight}</div>
+                <div className="card-body">
+                  {details.winner ? (
+                    details.claimed ? (
+                      <>
+                        <p>
+                          {details.coinbase} {CC_SYMBOL} claimed.
+                        </p>
+                      </>
+                    ) : (
+                      <>
+                        <p>
+                          {details.coinbase} {CC_SYMBOL}
+                        </p>
+                        <button
+                          className="btn btn-outline-primary"
+                          onClick={() => claimAction(uintCV(details.blockHeight))}
+                        >
+                          Claim
+                        </button>
+                      </>
+                    )
+                  ) : details.e ? (
                     <>
-                      {details.coinbase} {CC_SYMBOL} in Block {details.blockHeight} claimed.
+                      <p>
+                        Error for Block {details.blockHeight} {details.e.toString()}
+                      </p>
                     </>
                   ) : (
                     <>
-                      {details.coinbase} {CC_SYMBOL} in Block {details.blockHeight}
-                      <button onClick={() => claimAction(uintCV(details.blockHeight))}>
-                        Claim
-                      </button>
+                      <p>Pending tx for Block {details.blockHeight}</p>
                     </>
-                  )
-                ) : details.e ? (
-                  <>
-                    Error for Block {details.blockHeight} {details.e.toString()}
-                  </>
-                ) : (
-                  <>Pending tx for Block {details.blockHeight}</>
-                )}
-              </li>
+                  )}
+                </div>
+              </div>
             )
           )}
-        </ul>
+        </div>
       ) : loading ? null : (
         <div className="my-2">No rewards yet</div>
       )}

--- a/src/components/CityCoinStackingClaim.js
+++ b/src/components/CityCoinStackingClaim.js
@@ -66,11 +66,10 @@ export function CityCoinStackingClaim({ ownerStxAddress }) {
   return (
     <>
       <h3>Claim Stacking Rewards</h3>
-      <p>Available STX to claim:</p>
       {stackingState && stackingState.length > 0 ? (
-        <>
+        <div class="row">
           {stackingState.map((details, key) => (
-            <div className="card" key={key}>
+            <div className="col-3 card" key={key}>
               <div className="card-header">Cycle {details.cycleId}</div>
               <div className="card-body">
                 <p>{details.amountSTX.toLocaleString()} STX</p>
@@ -90,7 +89,7 @@ export function CityCoinStackingClaim({ ownerStxAddress }) {
               </div>
             </div>
           ))}
-        </>
+        </div>
       ) : loading ? null : (
         <div className="my-2">Nothing to claim</div>
       )}

--- a/src/components/CityCoinStackingClaim.js
+++ b/src/components/CityCoinStackingClaim.js
@@ -72,7 +72,7 @@ export function CityCoinStackingClaim({ ownerStxAddress }) {
             <div className="col-3 card" key={key}>
               <div className="card-header">Cycle {details.cycleId}</div>
               <div className="card-body">
-                <p>{details.amountSTX.toLocaleString()} STX</p>
+                <p>{(details.amountSTX / 1000000).toLocaleString()} STX</p>
                 <p>{details.amountCC.toLocaleString()} CityCoins</p>
                 <button
                   className="btn btn-outline-primary"

--- a/src/components/CityCoinTxList.js
+++ b/src/components/CityCoinTxList.js
@@ -221,7 +221,7 @@ function Details({ tx }) {
       <div className="col-lg-6 col-md-12 text-right">
         {tx.tx_id.substr(0, 10)}...
         <a href={`https://explorer.stacks.co/txid/${tx.tx_id}`} target="_blank" rel="noreferrer">
-          <i class="bi bi-box-arrow-up-right" />
+          <i className="bi bi-box-arrow-up-right" />
         </a>
       </div>
     </>


### PR DESCRIPTION
This PR changes the lists for each claim tab and converts it to a 3-column card.

This gives a visual container for each claim button, e.g.

![Screenshot from 2021-06-23 16-27-02](https://user-images.githubusercontent.com/9038904/123180397-0746ad80-d440-11eb-9e31-c75c66012bf7.png)

However, having a large amount of items is still not that great (see #22)

![Screenshot from 2021-06-23 16-28-58](https://user-images.githubusercontent.com/9038904/123180608-72907f80-d440-11eb-887d-b672536b8eed.png)

