### PR TITLE
Add additional checks and errors to mining

### DIFF
--- a/src/components/CityCoinMining.js
+++ b/src/components/CityCoinMining.js
@@ -113,7 +113,13 @@ export function CityCoinMining({ ownerStxAddress }) {
       if (totalSubmitted >= profileState.account.balance - estimatedFeeUstx) {
         setLoading(false);
         setError(true);
-        setErrorMsg(`Not enough funds to cover estimated transaction fee of ${estimatedFee} STX`);
+        setErrorMsg(
+          `Not enough funds to cover estimated transaction fee of ${estimatedFee} STX. Total Submitted: ${
+            totalSubmitted / 1000000
+          } STX, Estimated Fee ${estimatedFee} STX, Total Balance: ${
+            profileState.account.balance / 1000000
+          } STX`
+        );
       } else {
         try {
           await doContractCall({
@@ -267,7 +273,7 @@ export function CityCoinMining({ ownerStxAddress }) {
           />
           {buttonLabel}
         </button>
-        <div className={`alert alert-danger ${isError ? 'd-none' : ''}}`}>{errorMsg}</div>
+        <div className={`alert alert-danger ${isError ? '' : 'd-none'}`}>{errorMsg}</div>
         <div className="form-check">
           <input
             className="form-check-input"

--- a/src/components/CityCoinMining.js
+++ b/src/components/CityCoinMining.js
@@ -26,7 +26,8 @@ export function CityCoinMining({ ownerStxAddress }) {
   const memoRef = useRef();
   const [txId, setTxId] = useState();
   const [loading, setLoading] = useState();
-  const [error, setError] = useState(false);
+  const [isError, setError] = useState();
+  const [errorMsg, setErrorMsg] = useState('');
   const [buttonLabel, setButtonLabel] = useState('Mine');
   const [numberOfBlocks, setNumberOfBlocks] = useState();
   const [blockAmounts, setBlockAmounts] = useState([]);
@@ -65,8 +66,9 @@ export function CityCoinMining({ ownerStxAddress }) {
     miningAlert.innerHTML = '';
     setLoading(true);
     setError(false);
+    setErrorMsg('');
     if (numberOfBlocks === 1 && amountRef.current.value === '') {
-      miningAlert.innerHTML = 'Positive number required to mine.';
+      setErrorMsg('Positive number required to mine.');
       setLoading(false);
       setError(true);
     } else if (numberOfBlocks > 200) {
@@ -268,7 +270,9 @@ export function CityCoinMining({ ownerStxAddress }) {
           />
           {buttonLabel}
         </button>
-        <div className="alert alert-danger d-none" id="miningAlert"></div>
+        <div className={`${isError ? '' : 'd-none'} alert alert-danger }`} id="miningAlert">
+          {errorMsg}
+        </div>
         <div className="form-check">
           <input
             className="form-check-input"

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -1,6 +1,12 @@
 import { callReadOnlyFunction, cvToJSON, uintCV } from '@stacks/transactions';
 import { atom } from 'jotai';
-import { CITYCOIN_CORE, CONTRACT_DEPLOYER, NETWORK, STACKS_API_V2_INFO } from './constants';
+import {
+  CITYCOIN_CORE,
+  CONTRACT_DEPLOYER,
+  NETWORK,
+  STACKS_API_FEE_URL,
+  STACKS_API_V2_INFO,
+} from './constants';
 
 export const BLOCK_HEIGHT = atom({ value: 0, loading: false });
 export const REWARD_CYCLE = atom({ value: 0, loading: false });
@@ -44,4 +50,11 @@ export async function refreshRewardCycle(cycle) {
   } catch (e) {
     console.log(e);
   }
+}
+
+export async function getStxFees() {
+  // get estimated fee from API, returns integer
+  const result = await fetch(STACKS_API_FEE_URL);
+  const feeValue = await result.json();
+  return feeValue;
 }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -45,6 +45,7 @@ export const STACKS_API_WS_URL = localNode
   : 'wss://stacks-node-api.testnet.stacks.co/';
 export const STACKS_API_V2_INFO = `${STACKS_API_URL}/v2/info`;
 export const STACKS_API_ACCOUNTS_URL = `${STACKS_API_URL}/v2/accounts`;
+export const STACKS_API_FEE_URL = `${STACKS_API_URL}/v2/fees/transfer`;
 
 export const NETWORK = mainnet ? new StacksMainnet() : new StacksTestnet();
 NETWORK.coreApiUrl = STACKS_API_URL;


### PR DESCRIPTION
This PR adds some additional error handling to mining txs, including checking the profile balance against estimated fee (in integer, so usually = 1), and displays errors below the submit button. Also updates disclaimer to be clearer based on feedback in Discord.