### PR TITLE
Add reward cycle info

### DIFF
--- a/src/components/CityCoinStacking.js
+++ b/src/components/CityCoinStacking.js
@@ -83,8 +83,8 @@ export function CityCoinStacking({ ownerStxAddress }) {
         their Stacked CityCoins once the final selected cycle ends. You can Stack multiple times and
         for different reward cycle lengths.
       </p>
-      <div class="alert alert-info d-flex align-items-center" role="alert">
-        <i class="bi bi-info-circle fs-1 me-3"></i>
+      <div className="alert alert-info d-flex align-items-center" role="alert">
+        <i className="bi bi-info-circle fs-1 me-3"></i>
         <div>
           <p>For example, if you Stack 250,000 MIA for 2 cycles during reward cycle #0, then:</p>
           <ul>

--- a/src/components/CityCoinStacking.js
+++ b/src/components/CityCoinStacking.js
@@ -74,19 +74,42 @@ export function CityCoinStacking({ ownerStxAddress }) {
       <h3>Stack CityCoins</h3>
       <CurrentBlockHeight />
       <p>
-        Stacking CityCoins locks up the set amount in the contract for a number of reward cycles.
-        Once these reward cycles pass, CityCoin owners are eligible to withdraw their CityCoins in
-        addition to STX commited by miners during that reward cycle, proportionate to the amount
-        Stacked within that cycle.
+        Stacking CityCoins transfers and locks up the chosen amount in the contract for a number of
+        reward cycles, starting with the{' '}
+        <span className="fst-italic">next available reward cycle.</span>
       </p>
+      <p>
+        Stackers can claim STX rewards from miners for each cycle after it ends, and can reclaim
+        their Stacked CityCoins once the final selected cycle ends. You can Stack multiple times and
+        for different reward cycle lengths.
+      </p>
+      <div class="alert alert-info d-flex align-items-center" role="alert">
+        <i class="bi bi-info-circle fs-1 me-3"></i>
+        <div>
+          <p>For example, if you Stack 250,000 MIA for 2 cycles during reward cycle #0, then:</p>
+          <ul>
+            <li>Stacking will begin in reward cycle #1</li>
+            <li>After reward cycle #1 ends, STX rewards can be claimed</li>
+            <li>After reward cycle #2 ends, STX rewards and Stacked CityCoins can be claimed</li>
+          </ul>
+          <p>
+            For more information, please review{' '}
+            <a
+              rel="noreferrer"
+              target="_blank"
+              href="https://docs.citycoins.co/citycoins-core-protocol/stacking-citycoins"
+              className="alert-link"
+            >
+              Stacking in the documentation.
+            </a>
+          </p>
+        </div>
+      </div>
       <p>
         The first Stacking cycle begins at Block #26597, and to be eligible for rewards during that
         cycle, Stackers must lock their tokens prior to that block.
       </p>
-      <p>
-        You can submit for up to 32 cycles max, and will not be able to participate for one cycle
-        when it ends (also called a "cooldown period").
-      </p>
+      <p>One cycle is 2,100 blocks, or about two weeks. You can submit for up to 32 cycles max.</p>
       <form>
         <div className="input-group mb-3">
           <input

--- a/src/components/CityCoinStacking.js
+++ b/src/components/CityCoinStacking.js
@@ -75,6 +75,7 @@ export function CityCoinStacking({ ownerStxAddress }) {
       <h3>Stack CityCoins</h3>
       <CurrentBlockHeight />
       <CurrentRewardCycle />
+      <hr />
       <p>
         Stacking CityCoins transfers and locks up the chosen amount in the contract for a number of
         reward cycles, starting with the{' '}

--- a/src/components/CityCoinStacking.js
+++ b/src/components/CityCoinStacking.js
@@ -84,7 +84,7 @@ export function CityCoinStacking({ ownerStxAddress }) {
       <p>
         Stackers can claim STX rewards from miners for each cycle after it ends, and can reclaim
         their Stacked CityCoins once the locking period ends. You can Stack multiple times and for
-        different reward cycle lengths.
+        different reward cycle lengths but always with one cycle as a cooldown cycle.
       </p>
       <div className="alert alert-info d-flex align-items-center" role="alert">
         <i className="bi bi-info-circle fs-1 me-3"></i>

--- a/src/components/CityCoinStacking.js
+++ b/src/components/CityCoinStacking.js
@@ -109,8 +109,8 @@ export function CityCoinStacking({ ownerStxAddress }) {
         </div>
       </div>
       <p>
-        One cycle is 2,100 blocks or about two weeks. You can submit for up to 32 cycles max or
-        about 16 months.
+        One cycle is 2,100 Stacks blocks or about two weeks. You can submit for up to 32 cycles max
+        or about 16 months.
       </p>
       <form>
         <div className="input-group mb-3">

--- a/src/components/CityCoinStacking.js
+++ b/src/components/CityCoinStacking.js
@@ -83,8 +83,8 @@ export function CityCoinStacking({ ownerStxAddress }) {
       </p>
       <p>
         Stackers can claim STX rewards from miners for each cycle after it ends, and can reclaim
-        their Stacked CityCoins once the final selected cycle ends. You can Stack multiple times and
-        for different reward cycle lengths.
+        their Stacked CityCoins once the locking period ends. You can Stack multiple times and for
+        different reward cycle lengths.
       </p>
       <div className="alert alert-info d-flex align-items-center" role="alert">
         <i className="bi bi-info-circle fs-1 me-3"></i>

--- a/src/components/CityCoinStacking.js
+++ b/src/components/CityCoinStacking.js
@@ -18,6 +18,7 @@ import {
 } from '@stacks/transactions';
 import { getCityCoinBalance } from '../lib/citycoin';
 import { CurrentBlockHeight } from './CurrentBlockHeight';
+import { CurrentRewardCycle } from './CurrentRewardCycle';
 
 export function CityCoinStacking({ ownerStxAddress }) {
   const amountRefStacking = useRef();
@@ -73,6 +74,7 @@ export function CityCoinStacking({ ownerStxAddress }) {
     <>
       <h3>Stack CityCoins</h3>
       <CurrentBlockHeight />
+      <CurrentRewardCycle />
       <p>
         Stacking CityCoins transfers and locks up the chosen amount in the contract for a number of
         reward cycles, starting with the{' '}
@@ -106,10 +108,9 @@ export function CityCoinStacking({ ownerStxAddress }) {
         </div>
       </div>
       <p>
-        The first Stacking cycle begins at Block #26597, and to be eligible for rewards during that
-        cycle, Stackers must lock their tokens prior to that block.
+        One cycle is 2,100 blocks or about two weeks. You can submit for up to 32 cycles max or
+        about 16 months.
       </p>
-      <p>One cycle is 2,100 blocks, or about two weeks. You can submit for up to 32 cycles max.</p>
       <form>
         <div className="input-group mb-3">
           <input

--- a/src/components/CityCoinStackingClaim.js
+++ b/src/components/CityCoinStackingClaim.js
@@ -75,6 +75,8 @@ export function CityCoinStackingClaim({ ownerStxAddress }) {
     <>
       <h3>Claim Stacking Rewards</h3>
       <CurrentBlockHeight />
+      <CurrentRewardCycle />
+      <hr />
       <div className="my-2">
         <p>Coming soon!</p>
         <p>

--- a/src/components/CurrentRewardCycle.js
+++ b/src/components/CurrentRewardCycle.js
@@ -1,11 +1,18 @@
 import { useAtom } from 'jotai';
-import { useEffect } from 'react';
-import { BLOCK_HEIGHT, refreshBlockHeight, refreshRewardCycle, REWARD_CYCLE } from '../lib/blocks';
+import { useEffect, useState } from 'react';
+import {
+  BLOCK_HEIGHT,
+  getFirstBlockInCycle,
+  refreshBlockHeight,
+  refreshRewardCycle,
+  REWARD_CYCLE,
+} from '../lib/blocks';
 import { REWARD_CYCLE_LENGTH } from '../lib/constants';
 
 export function CurrentRewardCycle() {
   const [blockHeight, setBlockHeight] = useAtom(BLOCK_HEIGHT);
-  const [rewardCycle, setRewardCycle] = useAtom(REWARD_CYCLE);
+  const [rewardCycle, setRewardCycle] = useState();
+  const [firstBlockInCycle, setFirstBlockInCycle] = useState();
   const rewardCycleLength = REWARD_CYCLE_LENGTH;
 
   useEffect(() => {
@@ -13,11 +20,25 @@ export function CurrentRewardCycle() {
   }, [setBlockHeight]);
 
   useEffect(() => {
-    refreshRewardCycle(26600);
-  }, [setRewardCycle]);
+    refreshRewardCycle(blockHeight.value).then(cycle => {
+      setRewardCycle(cycle);
+    });
+    getFirstBlockInCycle(rewardCycle).then(firstBlock => {
+      setFirstBlockInCycle(firstBlock);
+    });
+  }, []);
 
-  if (!isNaN(rewardCycle.value)) {
-    return <p>Current Reward Cycle: {rewardCycle.value}</p>;
+  if (!isNaN(rewardCycle) && rewardCycle !== 0) {
+    return (
+      <>
+        <p>Current Reward Cycle: {rewardCycle}</p>
+        <ul>
+          {' '}
+          <li>First Block: {firstBlockInCycle}</li>
+          <li>Last Block: {firstBlockInCycle + rewardCycleLength}</li>
+        </ul>
+      </>
+    );
   } else {
     return <p>Current Reward Cycle: Unknown</p>;
   }

--- a/src/components/ProfileFull.js
+++ b/src/components/ProfileFull.js
@@ -117,6 +117,7 @@ export function ProfileFull({ stxAddress, userSession }) {
           )}
           <hr />
           <CurrentBlockHeight />
+          <CurrentRewardCycle />
         </div>
       </div>{' '}
     </div>

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -29,27 +29,37 @@ export async function refreshBlockHeight(block) {
   }
 }
 
-export async function refreshRewardCycle(cycle) {
+export async function refreshRewardCycle() {
   try {
-    cycle(v => {
-      return { value: v.value, loading: true };
-    });
+    const apiResult = await fetch(STACKS_API_V2_INFO);
+    const apiResultJson = await apiResult.json();
+    const block = apiResultJson.stacks_tip_height;
     const resultCV = await callReadOnlyFunction({
       contractAddress: CONTRACT_DEPLOYER,
       contractName: CITYCOIN_CORE,
       functionName: 'get-reward-cycle',
-      functionArgs: [uintCV(cycle.value)],
+      functionArgs: [uintCV(block)],
       network: NETWORK,
       senderAddress: CONTRACT_DEPLOYER,
     });
     const resultJSON = cvToJSON(resultCV);
-    console.log(`resultJSON: ${resultJSON}`);
-    cycle(() => {
-      return { value: cycle.value, loading: false };
-    });
+    return resultJSON.value.value;
   } catch (e) {
     console.log(e);
   }
+}
+
+export async function getFirstBlockInCycle(cycle) {
+  const resultCV = await callReadOnlyFunction({
+    contractAddress: CONTRACT_DEPLOYER,
+    contractName: CITYCOIN_CORE,
+    functionName: 'get-first-stacks-block-in-reward-cycle',
+    functionArgs: [uintCV(cycle)],
+    network: NETWORK,
+    senderAddress: CONTRACT_DEPLOYER,
+  });
+  const resultJSON = cvToJSON(resultCV);
+  return resultJSON.value;
 }
 
 export async function getStxFees() {


### PR DESCRIPTION
This PR adds a new component and some related functions to display the current reward cycle, start block height, and end block height on the stacking, stacking claim, and full profile.