### PR TITLE
fix error while loading stacking/mining stats

### DIFF
--- a/src/components/CityCoinDashboard.js
+++ b/src/components/CityCoinDashboard.js
@@ -31,7 +31,7 @@ export function CityCoinDashboard() {
                 <h5 className="card-title text-center">
                   Last Block ({(currentBlock.value - 1).toLocaleString()})
                 </h5>
-                <CityCoinMiningStats value={currentBlock.value - 1} />
+                <CityCoinMiningStats value={-1} />
               </div>
             </div>
           </div>
@@ -41,7 +41,7 @@ export function CityCoinDashboard() {
                 <h5 className="card-title text-center">
                   Current Block ({currentBlock.value.toLocaleString()})
                 </h5>
-                <CityCoinMiningStats value={currentBlock.value} />
+                <CityCoinMiningStats value={0} />
               </div>
             </div>
           </div>
@@ -51,7 +51,7 @@ export function CityCoinDashboard() {
                 <h5 className="card-title text-center">
                   Next Block ({(currentBlock.value + 1).toLocaleString()})
                 </h5>
-                <CityCoinMiningStats value={currentBlock.value + 1} />
+                <CityCoinMiningStats value={1} />
               </div>
             </div>
           </div>
@@ -68,7 +68,7 @@ export function CityCoinDashboard() {
                 <h5 className="card-title text-center">
                   Last Cycle ({currentRewardCycle.value - 1})
                 </h5>
-                <CityCoinStackingStats value={parseInt(currentRewardCycle.value - 1)} />
+                <CityCoinStackingStats value="-1" />
               </div>
             </div>
           </div>
@@ -78,7 +78,7 @@ export function CityCoinDashboard() {
                 <h5 className="card-title text-center">
                   Current Cycle ({currentRewardCycle.value})
                 </h5>
-                <CityCoinStackingStats value={parseInt(currentRewardCycle.value)} />
+                <CityCoinStackingStats value="0" />
               </div>
             </div>
           </div>
@@ -88,7 +88,7 @@ export function CityCoinDashboard() {
                 <h5 className="card-title text-center">
                   Next Cycle ({currentRewardCycle.value + 1})
                 </h5>
-                <CityCoinStackingStats value={parseInt(currentRewardCycle.value + 1)} />
+                <CityCoinStackingStats value="1" />
               </div>
             </div>
           </div>

--- a/src/components/CityCoinDashboard.js
+++ b/src/components/CityCoinDashboard.js
@@ -29,7 +29,7 @@ export function CityCoinDashboard() {
             <div className="card p-2 m-2">
               <div className="card-body">
                 <h5 className="card-title text-center">
-                  Last Block ({(currentBlock.value - 1).toLocaleString()})
+                  Last Block ({currentBlock.initialized ? (currentBlock.value - 1).toLocaleString() : "loading..."})
                 </h5>
                 <CityCoinMiningStats value={-1} />
               </div>
@@ -39,7 +39,7 @@ export function CityCoinDashboard() {
             <div className="card p-2 m-2">
               <div className="card-body">
                 <h5 className="card-title text-center">
-                  Current Block ({currentBlock.value.toLocaleString()})
+                  Current Block ({currentBlock.initialized ? currentBlock.value.toLocaleString() : "loading..."})
                 </h5>
                 <CityCoinMiningStats value={0} />
               </div>
@@ -49,7 +49,7 @@ export function CityCoinDashboard() {
             <div className="card p-2 m-2">
               <div className="card-body">
                 <h5 className="card-title text-center">
-                  Next Block ({(currentBlock.value + 1).toLocaleString()})
+                  Next Block ({currentBlock.initialized ? (currentBlock.value + 1).toLocaleString() : "loading..."})
                 </h5>
                 <CityCoinMiningStats value={1} />
               </div>
@@ -66,7 +66,7 @@ export function CityCoinDashboard() {
             <div className="card p-2 m-2">
               <div className="card-body">
                 <h5 className="card-title text-center">
-                  Last Cycle ({currentRewardCycle.value - 1})
+                  Last Cycle ({currentRewardCycle.initialized ? currentRewardCycle.value - 1 : "loading..."})
                 </h5>
                 <CityCoinStackingStats value="-1" />
               </div>
@@ -76,7 +76,7 @@ export function CityCoinDashboard() {
             <div className="card p-2 m-2">
               <div className="card-body">
                 <h5 className="card-title text-center">
-                  Current Cycle ({currentRewardCycle.value})
+                  Current Cycle ({currentRewardCycle.initialized ? currentRewardCycle.value : "loading..."})
                 </h5>
                 <CityCoinStackingStats value="0" />
               </div>
@@ -86,7 +86,7 @@ export function CityCoinDashboard() {
             <div className="card p-2 m-2">
               <div className="card-body">
                 <h5 className="card-title text-center">
-                  Next Cycle ({currentRewardCycle.value + 1})
+                  Next Cycle ({currentRewardCycle.initialized ? currentRewardCycle.value + 1 : "loading..."})
                 </h5>
                 <CityCoinStackingStats value="1" />
               </div>

--- a/src/components/CityCoinDashboard.js
+++ b/src/components/CityCoinDashboard.js
@@ -68,7 +68,7 @@ export function CityCoinDashboard() {
                 <h5 className="card-title text-center">
                   Last Cycle ({currentRewardCycle.initialized ? currentRewardCycle.value - 1 : "loading..."})
                 </h5>
-                <CityCoinStackingStats value="-1" />
+                <CityCoinStackingStats value={-1}/>
               </div>
             </div>
           </div>
@@ -78,7 +78,7 @@ export function CityCoinDashboard() {
                 <h5 className="card-title text-center">
                   Current Cycle ({currentRewardCycle.initialized ? currentRewardCycle.value : "loading..."})
                 </h5>
-                <CityCoinStackingStats value="0" />
+                <CityCoinStackingStats value={0} />
               </div>
             </div>
           </div>
@@ -88,7 +88,7 @@ export function CityCoinDashboard() {
                 <h5 className="card-title text-center">
                   Next Cycle ({currentRewardCycle.initialized ? currentRewardCycle.value + 1 : "loading..."})
                 </h5>
-                <CityCoinStackingStats value="1" />
+                <CityCoinStackingStats value={1} />
               </div>
             </div>
           </div>

--- a/src/components/CityCoinMiningStats.js
+++ b/src/components/CityCoinMiningStats.js
@@ -13,7 +13,7 @@ export function CityCoinMiningStats(offset) {
 
 
   useEffect(() => {
-    if(!blockHeight.loading && blockHeight.initialized) {
+    if(blockHeight.initialized) {
       getMiningStatsAtBlock(blockHeight.value + offset.value).then(result => {
         setMiningStats(result);
         setTotalMiners(result.value.value.minersCount.value);

--- a/src/components/CityCoinMiningStats.js
+++ b/src/components/CityCoinMiningStats.js
@@ -1,22 +1,28 @@
 import { useEffect, useState } from 'react';
 import { getMiningStatsAtBlock } from '../lib/citycoin';
+import { useAtom } from 'jotai';
+import { BLOCK_HEIGHT } from '../lib/blocks';
 
-export function CityCoinMiningStats(blockHeight) {
+export function CityCoinMiningStats(offset) {
   const [miningStats, setMiningStats] = useState();
   const [totalMiners, setTotalMiners] = useState();
   const [totalAmountStx, setTotalAmountStx] = useState();
   const [totalAmountToCity, setTotalAmountToCity] = useState();
   const [totalAmountToStackers, setTotalAmountToStackers] = useState();
+  const [blockHeight] = useAtom(BLOCK_HEIGHT);
+
 
   useEffect(() => {
-    getMiningStatsAtBlock(blockHeight.value).then(result => {
-      setMiningStats(result);
-      setTotalMiners(result.value.value.minersCount.value);
-      setTotalAmountStx(result.value.value.amount.value / 1000000);
-      setTotalAmountToCity(result.value.value.amountToCity.value / 1000000);
-      setTotalAmountToStackers(result.value.value.amountToStackers.value / 1000000);
-    });
-  }, [setMiningStats]);
+    if(!blockHeight.loading && blockHeight.initialized) {
+      getMiningStatsAtBlock(blockHeight.value + offset.value).then(result => {
+        setMiningStats(result);
+        setTotalMiners(result.value.value.minersCount.value);
+        setTotalAmountStx(result.value.value.amount.value / 1000000);
+        setTotalAmountToCity(result.value.value.amountToCity.value / 1000000);
+        setTotalAmountToStackers(result.value.value.amountToStackers.value / 1000000);
+      });
+    }
+  }, [setMiningStats, blockHeight.value]);
 
   return (
     <>

--- a/src/components/CityCoinStackingStats.js
+++ b/src/components/CityCoinStackingStats.js
@@ -20,14 +20,16 @@ export function CityCoinStackingStats(offset) {
       setAmountToken(result.value.amountToken.value);
     });
   }
-  }, [setStackingStats, rewardCycle.value]);
+  }, [rewardCycle.value]);
 
   useEffect(() => {
-    getFirstStacksBlockInRewardCycle(rewardCycle.value).then(result => {
-      console.log(`rewardCycle: ${rewardCycle.value}\nresult: ${result}`);
-      setStackingBlock(result);
-    });
-  }, [setStackingBlock]);
+    if(rewardCycle.initialized) {
+      getFirstStacksBlockInRewardCycle(rewardCycle.value + offset.value).then(result => {
+        console.log(`rewardCycle: ${rewardCycle.value + offset.value}\nresult: ${result}`);
+        setStackingBlock(result);
+      });
+    }
+  }, [rewardCycle.value]);
 
   return (
     <>

--- a/src/components/CityCoinStackingStats.js
+++ b/src/components/CityCoinStackingStats.js
@@ -1,21 +1,26 @@
 import { useEffect, useState } from 'react';
 import { getFirstStacksBlockInRewardCycle, getStackingStatsAtCycle } from '../lib/citycoin';
 import { REWARD_CYCLE_LENGTH } from '../lib/constants';
+import { useAtom } from 'jotai';
+import { REWARD_CYCLE } from '../lib/blocks';
 
-export function CityCoinStackingStats(rewardCycle) {
+export function CityCoinStackingStats(offset) {
   const [stackingStats, setStackingStats] = useState();
   const [amountStx, setAmountStx] = useState();
   const [amountToken, setAmountToken] = useState();
   const [stackingBlock, setStackingBlock] = useState();
+  const [rewardCycle] = useAtom(REWARD_CYCLE);
 
   useEffect(() => {
-    getStackingStatsAtCycle(rewardCycle.value).then(result => {
+    if(!rewardCycle.loading && rewardCycle.initialized) {
+    getStackingStatsAtCycle(rewardCycle.value + offset.value).then(result => {
       console.log(result);
       setStackingStats(result);
       setAmountStx(result.value.amountUstx.value / 1000000);
       setAmountToken(result.value.amountToken.value);
     });
-  }, [setStackingStats]);
+  }
+  }, [setStackingStats, rewardCycle.value]);
 
   useEffect(() => {
     getFirstStacksBlockInRewardCycle(rewardCycle.value).then(result => {

--- a/src/components/CityCoinStackingStats.js
+++ b/src/components/CityCoinStackingStats.js
@@ -12,7 +12,7 @@ export function CityCoinStackingStats(offset) {
   const [rewardCycle] = useAtom(REWARD_CYCLE);
 
   useEffect(() => {
-    if(!rewardCycle.loading && rewardCycle.initialized) {
+    if(rewardCycle.initialized) {
     getStackingStatsAtCycle(rewardCycle.value + offset.value).then(result => {
       console.log(result);
       setStackingStats(result);

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -8,23 +8,23 @@ import {
   STACKS_API_V2_INFO,
 } from './constants';
 
-export const BLOCK_HEIGHT = atom({ value: 0, loading: false });
-export const REWARD_CYCLE = atom({ value: 0, loading: false });
+export const BLOCK_HEIGHT = atom({ value: 0, loading: false, initialized: false });
+export const REWARD_CYCLE = atom({ value: 0, loading: false, initialized: false });
 
 export async function refreshBlockHeight(block) {
   try {
     block(v => {
-      return { value: v.value, loading: true };
+      return { value: v.value, loading: true, initialized: v.initialized };
     });
     const result = await fetch(STACKS_API_V2_INFO);
     const resultJson = await result.json();
     block(() => {
-      return { value: resultJson?.stacks_tip_height, loading: false };
+      return { value: resultJson?.stacks_tip_height, loading: false, initialized: true };
     });
   } catch (e) {
     console.log(e);
     block(v => {
-      return { value: v.value, loading: false };
+      return { value: v.value, loading: false, initialized: true };
     });
   }
 }
@@ -33,7 +33,7 @@ export async function refreshRewardCycle(cycle, blockHeight) {
   if (blockHeight) {
     try {
       cycle(v => {
-        return { value: v.value, loading: true };
+        return { value: v.value, loading: true, initialized: v.initialized };
       });
       const resultCV = await callReadOnlyFunction({
         contractAddress: CONTRACT_DEPLOYER,
@@ -51,7 +51,7 @@ export async function refreshRewardCycle(cycle, blockHeight) {
         } else {
           value = 'not found';
         }
-        return { value, loading: false };
+        return { value, loading: false, initialized: true};
       });
     } catch (e) {
       console.log(e);


### PR DESCRIPTION
This PR fixes problem described in: https://github.com/citycoins/citycoin-ui/pull/80#issuecomment-916312725

I added `initialized` attribute to BLOCK_HEIGHT and REWARD_CYCLE to know exactly if we are dealing with initial, default data or with data fetch from the chain.

Instead of passing to components exact block height or cycle for which we want to fetch the data I decided to pass offset and let components calculate correct value by itself.
And finally I wrapped `getMiningStatsAtBlock` and `getMiningStatsAtBlock` with simple if statement, to prevent calling them when atoms aren't initialized yet.
