### PR TITLE
Fix max supply calculation for MIA

### DIFF
--- a/src/components/MiamiCoin.js
+++ b/src/components/MiamiCoin.js
@@ -37,7 +37,15 @@ export function MiamiCoin() {
     });
   }, []);
 
-  const maxSupply = (currentBlock.value - MIAMICOIN_START_BLOCK) * 250000;
+  // hardcoded for now, could use contract interactions
+  const bonusPeriod = 10000;
+  let maxSupply = 0;
+  let blocksPast = currentBlock.value - MIAMICOIN_START_BLOCK;
+  if (blocksPast > bonusPeriod) {
+    maxSupply = bonusPeriod * 250000 + (blocksPast - bonusPeriod) * 100000;
+  } else {
+    maxSupply = (currentBlock.value - MIAMICOIN_START_BLOCK) * 250000;
+  }
 
   return (
     <div className="container pt-3">


### PR DESCRIPTION
With the end of the bonus period coming up soon, max supply needs to use different math if more than 10,000 blocks have passed since the activation height.

This is a quick fix - it just hardcodes the math for now. Ideally this would interact with the contract to get the correct values, especially as future CityCoins launch.