### PR TITLE
Bug fix in Claim Mining Rewards page

### DIFF
--- a/src/components/mining/ClaimMiningRewards.js
+++ b/src/components/mining/ClaimMiningRewards.js
@@ -171,7 +171,7 @@ export default function ClaimMiningRewards(props) {
       <CurrentStacksBlock />
       <p>
         The winner for a block can be queried after 100 blocks pass (~16-17hrs), and the winner can
-        claim newly minted MIA.
+        claim newly minted {props.token.symbol}.
       </p>
       <p>
         There is only one winner per block, and STX sent to the contract for mining are not


### PR DESCRIPTION
## Issue
This PR attempts to fix issue [#113 BUG Hardcoded MIA text on claim mining rewards
](https://github.com/citycoins/citycoin-ui/issues/113). 

## How to Reproduce
Go to [Mining page](https://minecitycoins.com/nyc/mining?chain=mainnet) 
Click on Claim Rewards
Text says "newly minted MIA" regardless of selection
 
## Solution 
Uses props.token.symbol instead of the hard coded string. 